### PR TITLE
bugfix getWorksheetByName(leftmost-sheet)

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ function GoogleSpreadsheetAsPromised() {
     this.getWorksheetByName = function(name) {
         return new Promise(function(resolve, reject) {
             var index = self.worksheetNames[name];
-            if (!index) {
+            if (index === undefined) {
                 return reject("Cannot find worksheet name: `" + name + "`");
             }
             self.getWorksheet(index).then(function(worksheetAsPromised) {


### PR DESCRIPTION
Hi
I have fixed `getWorksheetByName(title)`

## bug

when call `sheet.getWorksheetByName('sheet1')` on following spreadsheet

![](https://gyazo.com/df84cf2117e3f9f0369b72419b7338f6/raw)

`var index = self.worksheetNames[name];` becomes `0`.

![](https://gyazo.com/4bc2309af6505b22f2e4dc0cd10d7a17/raw)

## fix
worksheet id `0` is ok, so compare `index` with `undefined`.